### PR TITLE
Move JIRA rescan user task to task queue

### DIFF
--- a/openedx_webhooks/tasks/__init__.py
+++ b/openedx_webhooks/tasks/__init__.py
@@ -25,5 +25,5 @@ def status(task_id):
 
 # Working in a Celery task means we can't take advantage of Flask-Dance's
 # session proxies, so we'll explicitly define the sessions here.
-github = github_bp.session
-jira = jira_bp.session
+github_session = github_bp.session
+jira_session = jira_bp.session

--- a/openedx_webhooks/tasks/github.py
+++ b/openedx_webhooks/tasks/github.py
@@ -9,7 +9,9 @@ from iso8601 import parse_date
 from flask import render_template
 
 from openedx_webhooks import sentry, celery
-from openedx_webhooks.tasks import logger, github, jira
+from openedx_webhooks.tasks import logger
+from openedx_webhooks.tasks import github_session as github
+from openedx_webhooks.tasks import jira_session as jira
 from openedx_webhooks.info import (
     get_people_file, is_internal_pull_request, is_contractor_pull_request
 )

--- a/openedx_webhooks/tasks/jira.py
+++ b/openedx_webhooks/tasks/jira.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+from __future__ import unicode_literals, print_function
+
+from collections import defaultdict
+
+from openedx_webhooks import sentry, celery
+from openedx_webhooks.tasks import logger
+from openedx_webhooks.tasks import jira_session as jira
+from openedx_webhooks.utils import jira_users, jira_group_members
+
+
+@celery.task
+def rescan_users(domain_groups):
+    failures = defaultdict(dict)
+    for groupname, domain in domain_groups.items():
+        users_in_group = jira_group_members(groupname, session=jira, debug=True)
+        usernames_in_group = set(u["name"] for u in users_in_group)
+        sentry.client.extra_context({
+            "groupname": groupname,
+            "usernames_in_group": usernames_in_group,
+        })
+
+        for user in jira_users(filter=domain, session=jira, debug=True):
+            if not user["email"].endswith(domain):
+                pass
+            username = user["name"]
+            if username not in usernames_in_group:
+                # add the user to the group!
+                resp = jira.post(
+                    "/rest/api/2/group/user?groupname={}".format(groupname),
+                    json={"name": username},
+                )
+                if not resp.ok:
+                    failures[groupname][username] = resp.text
+
+    if failures:
+        logger.error("Failures in trying to rescan JIRA users: {}".format(failures))
+    return failures


### PR DESCRIPTION
Our load on the webservers is still very spiky, and it appears to be spiking once per hour. I'm betting it's because of the "rescan JIRA users" task which is run once every hour. Moving this to the task queue will smooth our the load on the webservers, which will hopefully make them more reliable.