### PR TITLE
Use the name of the end state rather than the name of the transition

### DIFF
--- a/openedx_webhooks/jira_views.py
+++ b/openedx_webhooks/jira_views.py
@@ -183,7 +183,7 @@ def issue_opened(issue):
         # Note that a transition may not have the same name as the state that it
         # goes to, so a transition to go from "Open" to "In Progress" may be
         # named something like "Start Work".
-        transitions = {t["name"]: t["id"] for t in transitions_resp.json()["transitions"]}
+        transitions = {t["to"]["name"]: t["id"] for t in transitions_resp.json()["transitions"]}
 
         # We attempt to transition the issue into the "Open" state for the given project
         # (some projects use a different name), so look for a transition with the right name


### PR DESCRIPTION
In JIRA, you can name a state transition whatever you want -- the default name
is the name of the end state, but you can change that. It looks like the API
does expose the name of the end state, so we should key off of that, in case
the transition has a different name from the end state.

Note that this assumes that there will never be more than one transition ending
at the same state. If that happens, one of them will be clobbered. (It's not
clear that we have a good way of dealing with that even before this change.)