### PR TITLE
Add some docs info to the internal PR cover letter.

### DIFF
--- a/openedx_webhooks/templates/github_pr_cover_letter.md.j2
+++ b/openedx_webhooks/templates/github_pr_cover_letter.md.j2
@@ -18,10 +18,14 @@
 If you've been tagged for review, please check your corresponding box once you've given the :+1:.
 - [ ] Code review #1
 - [ ] Code review #2
-- [ ] UI strings/error msgs review
+- [ ] Docs review (required for UI strings/error messages)
 - [ ] UX review
 - [ ] Accessibility review
 - [ ] Product review
+
+# Documentation considerations
+- [ ] Are there user visible changes? If so, list who is affected, and include a pointer to the relevant code.
+- [ ] Should this be mentioned in the release notes? If so, make sure that you included a description.
 
 # DevOps assistance
 {% filter replace("\n", " ")|trim %}


### PR DESCRIPTION
@nedbat @lamagnifica, I've added a bit of text for documentation in the base cover letter. How's this look?