### PR TITLE
IT-534 - Removed and Changed Group Auto-Assignation Rules

### DIFF
--- a/openedx_webhooks/jira_views.py
+++ b/openedx_webhooks/jira_views.py
@@ -527,10 +527,8 @@ def jira_issue_comment_added(issue, comment):
 
 # a mapping of group name to email domain
 domain_groups = {
-    "edx-employees": "@edx.org",
-    "qualcomm": ".qualcomm.com",
-    "ubc": "@cs.ubc.ca",
-    "ubc": "@ubc.ca",
+    "partner-ubc": "@cs.ubc.ca",
+    "partner-ubc": "@ubc.ca",
 }
 
 


### PR DESCRIPTION
For IT-534:
* Removed group auto-assignation for edx-employees and qualcomm.
* Updated group auto-assignation for ubc to partner-ubc until we discover the implications.
