### PR TITLE
Additional logging for GitHub PR web hook Celery tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn openedx_webhooks:create_app\(\) --log-file -
-worker: celery worker --app=openedx_webhooks.worker
+worker: celery worker -A openedx_webhooks.worker -l INFO

--- a/openedx_webhooks/config.py
+++ b/openedx_webhooks/config.py
@@ -24,7 +24,11 @@ class DefaultConfig(object):
 
 class WorkerConfig(DefaultConfig):
     # CELERY_BROKER_URL = os.environ.get("RABBITMQ_BIGWIG_RX_URL", "amqp://")
-    pass
+    CELERY_IMPORTS = (
+        'openedx_webhooks.tasks.github',
+        'openedx_webhooks.tasks.jira',
+        'openedx_webhooks.tasks.example',
+    )
 
 
 class DevelopmentConfig(DefaultConfig):

--- a/openedx_webhooks/tasks/example.py
+++ b/openedx_webhooks/tasks/example.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Example Celery task, can be used for testing the Celery infrastructure
+at Heroku.
+
+Example usage::
+
+    from openedx_webhooks.tasks.example import add
+    add.delay(1, 2)
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from openedx_webhooks import celery
+from openedx_webhooks.tasks.utils import log_info
+
+celery.conf.update({
+    'BROKER_URL': 'ironmq://',
+    'CELERY_TASK_SERIALIZER': 'json',
+    'CELERY_RESULT_SERIALIZER': 'json',
+})
+
+
+@celery.task(name='example.add', bind=True)
+def add(self, num1, num2):
+    """
+    Example Celery task.
+
+    Args:
+        num1 (int): First number
+        num2 (int): Second number
+
+    Returns:
+        int: Sum
+    """
+    result = num1 + num2
+    msg = "Results for `{}`: {}".format(self.name, result)
+    log_info(self.request, msg)
+    return result

--- a/openedx_webhooks/tasks/utils.py
+++ b/openedx_webhooks/tasks/utils.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Utility functions in support of Celery tasks
+
+More information about referenced class objects below:
+
+-  `celery.Task.request`_
+-  `requests.PreparedRequest`_
+-  `requests.Response`_
+
+.. _celery.Task.request: http://docs.celeryproject.org/en/latest/userguide/tasks.html#context
+.. _requests.PreparedRequest: http://docs.python-requests.org/en/master/api/#requests.PreparedRequest
+.. _requests.Response: http://docs.python-requests.org/en/master/api/#requests.Response
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from openedx_webhooks.tasks import logger
+
+
+def _log(log_fn, task_request, message):
+    """
+    Logs a message using the supplied logging function.
+
+    Arguments:
+        log_fn: logging.Logger instance method to render log message
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        message (str): Log message
+    """
+    log_fn("{}: {}".format(task_request.id, message))
+
+
+def log_info(task_request, message):
+    """
+    Logs a message using Celery's app logger at the INFO level.
+
+    Arguments:
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        message (str): Log message
+    """
+    _log(logger.info, task_request, message)
+
+
+def log_error(task_request, message):
+    """
+    Logs a message using Celery's app logger at the ERROR level.
+
+    Arguments:
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        message (str): Log message
+    """
+    _log(logger.error, task_request, message)
+
+
+def log_request(task_request, request):
+    """
+    Logs HTTP request message using Celery's app logger.
+
+    Arguments:
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        request (requests.PreparedRequest): the HTTP request
+    """
+    msg = "{0.method} {0.url}: {0.body}".format(request)
+    log_info(task_request, msg)
+
+
+def log_response(task_request, response):
+    """
+    Logs HTTP response message using Celery's app logger.
+
+    Arguments:
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        response (requests.Response): the HTTP response
+    """
+    msg = "{status_code} {reason} for {url}: {content}".format(**response)
+    log_info(task_request, msg)
+
+
+def log_request_response(task_request, response):
+    """
+    Logs HTTP request and response messages using Celery's app logger.
+
+    Arguments:
+        task_request (celery.Task.request): instance of request used to
+            call this function
+        response (requests.Response): the HTTP response
+    """
+    log_request(task_request, response.request)
+    log_response(task_request, response)

--- a/tests/tasks/test_example.py
+++ b/tests/tasks/test_example.py
@@ -1,0 +1,5 @@
+from openedx_webhooks.tasks.example import add
+
+
+def test_add():
+    assert add(5, 6) == 11


### PR DESCRIPTION
Add logging for Celery tasks which are used to handle GitHub PR open and close events.

Also:
* Make sure Heroku Celery worker task actually outputs logging statements
* Created an example Celery task to test logging and establish testing pattern

/cc @edx/ospr 
