### PR TITLE
Update OSPRs with GitHub activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache
 .coverage
 .env
+Procfile.local
 README.md
 build/
 dist/

--- a/HOWTO-activate-jira-github-activity.rst
+++ b/HOWTO-activate-jira-github-activity.rst
@@ -1,0 +1,53 @@
+How To Activate Recording GitHub Activities in JIRA Issues
+==========================================================
+
+Currently we have the code to receive GitHub PR events via webhooks, and
+record them in JIRA. However, we don't want to activate this code yet
+until we've determined that we can tune the workflow to the appropriate
+level of email notifications.
+
+In order to activate this feature:
+
+1. Add the following config vars at Heroku:
+
+   -  [ ] GITHUB\_PERSONAL\_TOKEN
+   -  [ ] GITHUB\_WEBHOOKS\_SECRET
+   -  [ ] JIRA\_ACCESS\_TOKEN
+   -  [ ] JIRA\_ACCESS\_TOKEN\_SECRET
+   -  [ ] JIRA\_OAUTH\_PRIVATE\_KEY
+   -  [ ] JIRA\_SERVER
+   -  [ ] RQ\_WORKER\_LOGGING\_LEVEL
+
+2. Add ``rqworker`` dyno type
+
+   ::
+
+       heroku ps:scale rqworker=1 -a openedx-webhooks
+
+3. Install the webhooks at various repos by using the
+   ``bin/gh_list_repos_with_webhook.py`` command. This command can be
+   run locally or remotely at Heroku.
+
+4. Add the following webhook configuration to
+   ``openedx_webhooks.webhook_confs.WEBHOOK_CONFS``:
+
+   .. code:: python
+
+       {
+           'config': {
+               'url': url_for("github_views.hook_receiver", _external=True),
+               'content_type': 'json',
+               'insecure_ssl': False,
+               'secret': os.environ.get('GITHUB_WEBHOOKS_SECRET'),
+           },
+           'events': [
+               'issue_comment',
+               'pull_request',
+               'pull_request_review',
+               'pull_request_review_comment',
+           ]
+       }
+
+5. Commit changes to GitHub
+6. Deploy to ``openedx-webhooks-staging`` at Heroku
+7. Promote from staging to ``openedx-webhooks`` at Heroku

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: gunicorn openedx_webhooks:create_app\(\) --log-file -
 worker: celery worker -A openedx_webhooks.worker -l INFO
+rqworker: python rq_worker.py

--- a/bin/get_task_result_errors.py
+++ b/bin/get_task_result_errors.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import csv
 import json

--- a/bin/gh_list_repos_with_webhook.py
+++ b/bin/gh_list_repos_with_webhook.py
@@ -1,0 +1,1 @@
+../openedx_webhooks/lib/github/bin/list_repos_with_webhook.py

--- a/bin/gh_update_or_create_webhooks.py
+++ b/bin/gh_update_or_create_webhooks.py
@@ -1,0 +1,1 @@
+../openedx_webhooks/lib/github/bin/update_or_create_webhooks.py

--- a/openedx_webhooks/config.py
+++ b/openedx_webhooks/config.py
@@ -8,6 +8,7 @@ class DefaultConfig(object):
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///openedx_webhooks.db")
     GITHUB_OAUTH_CLIENT_ID = os.environ.get("GITHUB_OAUTH_CLIENT_ID")
     GITHUB_OAUTH_CLIENT_SECRET = os.environ.get("GITHUB_OAUTH_CLIENT_SECRET")
+    GITHUB_WEBHOOKS_SECRET = os.environ.get("GITHUB_WEBHOOKS_SECRET")
     JIRA_OAUTH_CONSUMER_KEY = os.environ.get("JIRA_OAUTH_CONSUMER_KEY")
     JIRA_OAUTH_RSA_KEY = os.environ.get("JIRA_OAUTH_RSA_KEY")
     CELERY_ACCEPT_CONTENT = ["json"]

--- a/openedx_webhooks/github/__init__.py
+++ b/openedx_webhooks/github/__init__.py
@@ -1,0 +1,9 @@
+"""
+Handle incoming GitHub events.
+
+Subpacakges and modules:
+
+-  ``dispatcher``: Receive incoming events from the Flask view, and
+   delegate processing to individual rules.
+-  ``models``: Domain models.
+"""

--- a/openedx_webhooks/github/dispatcher/__init__.py
+++ b/openedx_webhooks/github/dispatcher/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Dispatch incoming webhook events to each rule.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ...lib.github.models import GithubWebHookRequestHeader
+from .rules import RULES
+
+
+def dispatch(raw_headers, event):
+    """
+    Determine how an event needs to be processed.
+
+    Arguments:
+        raw_headers (flask.Request.headers)
+        event (Dict[str, Any]): The parsed event payload
+    """
+    event_type = GithubWebHookRequestHeader(raw_headers).event_type
+
+    for rule in RULES:
+        rule.run(event_type, event)

--- a/openedx_webhooks/github/dispatcher/rules/__init__.py
+++ b/openedx_webhooks/github/dispatcher/rules/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+r"""
+Rules evaluted by the dispatcher.
+
+Each dispatcher rule determines whether an event requires additional
+processing. Each rule implements the ``run(event_type, event)``
+interface.
+
+Inputs
+------
+
+-  `event\_type`_ is one of the GitHub event types as delivered via the
+   ``X-Github-Event`` header.
+
+-  event is the event payload parsed into a Python ``dict``.
+
+.. _event\_type: https://developer.github.com/v3/activity/events/types/
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from . import github_activity
+
+RULES = [
+    github_activity,
+]
+"""
+List[Module, ...]: A list of rules to process, in order
+"""

--- a/openedx_webhooks/github/dispatcher/rules/github_activity.py
+++ b/openedx_webhooks/github/dispatcher/rules/github_activity.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+Update JIRA issue with latest GitHub activity.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ....jira.tasks import update_latest_github_activity
+from ....lib.jira import jira
+from ...models import GithubEvent
+
+
+def _find_issues_for_pull_request(pull_request_url, jira=jira):
+    """
+    Find corresponding JIRA issues for a given GitHub pull request.
+
+    Arguments:
+        pull_request_url (str)
+        jira (jira.JIRA)
+
+    Returns:
+        jira.client.ResultList[jira.Issue]
+    """
+    jql = 'project=OSPR AND url="{}"'.format(pull_request_url)
+    return jira.search_issues(jql)
+
+
+def _process(event_type, raw_event):
+    """
+    Update each corresponding JIRA issue with GitHub activity.
+
+    Arguments:
+        event_type (str): GitHub event type
+        raw_event (Dict[str, Any]): The parsed event payload
+    """
+    event = GithubEvent(event_type, raw_event)
+    issues = _find_issues_for_pull_request(event.html_url)
+    for issue in issues:
+        update_latest_github_activity(
+            issue.id,
+            event.description,
+            event.user.login,
+            event.updated_at,
+            event.is_edx_user,
+        )
+
+
+def run(event_type, raw_event):
+    """
+    Process the incoming event.
+
+    Arguments:
+        event_type (str): `GitHub event type`_
+        raw_event (Dict[str, Any]): The parsed event payload
+
+    .. _GitHub event type:
+        https://developer.github.com/v3/activity/events/types/
+    """
+    event_types = (
+        'issue_comment',
+        'pull_request',
+        'pull_request_review',
+        'pull_request_review_comment',
+    )
+    if event_type in event_types:
+        _process(event_type, raw_event)

--- a/openedx_webhooks/github/models.py
+++ b/openedx_webhooks/github/models.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+GitHub related domain models.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..lib.edx_repo_tools_data.utils import get_people
+from ..lib.github.models import GithubWebHookEvent
+
+
+class GithubEvent(GithubWebHookEvent):
+    """
+    A GitHub webhook event.
+
+    Attributes:
+        event_type (str): GitHub event type
+        event (Dict[str, Any]): The parsed event payload
+        get_people (Callable[[], ..lib.edx_repo_tools_data.models.People]):
+            Function used to get `people.yaml` folks
+    """
+
+    def __init__(self, event_type, event, get_people=get_people):
+        """
+        Init.
+
+        Arguments:
+            event_type (str): GitHub event type
+            event (Dict[str, Any]): The parsed event payload
+            get_people (Callable[[], ..lib.edx_repo_tools_data.models.People]):
+                Function used to get `people.yaml` folks
+        """
+        super(GithubEvent, self).__init__(event_type, event)
+        self.get_people = get_people
+
+    @property
+    def is_edx_user(self):
+        """
+        bool: Is the user who sent the event part of edX.
+        """
+        return self.user.is_edx_user
+
+    @property
+    def user(self):
+        """
+        openedx_webhooks.lib.edx_repo_tools_data.models.Person: Activity user.
+        """
+        people = self.get_people()
+        return people.get(self.sender_login)

--- a/openedx_webhooks/jira/__init__.py
+++ b/openedx_webhooks/jira/__init__.py
@@ -1,0 +1,7 @@
+"""
+JIRA related tasks.
+
+Subpacakges:
+
+-  ``tasks``: Tasks that update JIRA.
+"""

--- a/openedx_webhooks/jira/tasks.py
+++ b/openedx_webhooks/jira/tasks.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+Tasks that update JIRA in some way.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import namedtuple
+
+from ..lib.jira import jira
+from ..lib.jira.utils import (
+    convert_to_jira_datetime_string, find_allowed_values, make_fields_lookup
+)
+
+JiraGithubPrFieldNames = namedtuple('_JiraGithubPrFieldNames', (
+    'LAST_UPDATED_AT',
+    'LAST_UPDATED_BY',
+    'LATEST_ACTION',
+    'LATEST_BY_EDX',
+))
+
+JIRA_PR_FIELDS = JiraGithubPrFieldNames(
+    LAST_UPDATED_AT='GitHub PR Last Updated At',
+    LAST_UPDATED_BY='GitHub PR Last Updated By',
+    LATEST_ACTION='GitHub Latest Action',
+    LATEST_BY_EDX='GitHub Latest Action By edX',
+)
+
+JIRA_FIELDS_ID_LOOKUP = make_fields_lookup(JIRA_PR_FIELDS._asdict().values())
+"""
+Dict[str, str]: Mapping of JIRA field names to IDs
+"""
+
+
+def _make_edx_action_choices(find_allowed_values=find_allowed_values):
+    # TODO: Test
+    values = find_allowed_values(
+        'OSPR',
+        'Pull Request Review',
+        'GitHub Latest Action By edX'
+    )
+    choices = {
+        True: next(v for v in values if v['value'] == 'Yes'),
+        False: next(v for v in values if v['value'] == 'No'),
+    }
+    return choices
+
+JIRA_EDX_ACTION_CHOICES = _make_edx_action_choices()
+"""
+Dict[bool, Dict[str, str]]: Mapping of Boolean values to JIRA choices for
+    ``OSPR:Pull Request Review:GitHub Latest Action By edX`` field
+"""
+
+
+def update_latest_github_activity(
+        issue_id, description, login, updated_at, is_edx_user, jira=jira
+):
+    """
+    Update JIRA issue with latest GitHub activity data.
+
+    Arguments:
+        issue_id (str): The JIRA issue ID
+        description (str): Description of GitHub activity
+        login (str): GitHub login of user who generated the activity
+        updated_at (datetime.datetime): Datetime of when the activity happened
+        is_edx_user (bool): Is the user associated with edX?
+        jira (jira.JIRA): JIRA API client instance
+    """
+    issue = jira.issue(issue_id)
+    update_dt = convert_to_jira_datetime_string(updated_at)
+    latest_by_edx = JIRA_EDX_ACTION_CHOICES[is_edx_user]
+
+    fields = {
+        JIRA_PR_FIELDS.LATEST_ACTION: description,
+        JIRA_PR_FIELDS.LAST_UPDATED_BY: login,
+        JIRA_PR_FIELDS.LAST_UPDATED_AT: update_dt,
+        JIRA_PR_FIELDS.LATEST_BY_EDX: latest_by_edx,
+    }
+
+    fields = {JIRA_FIELDS_ID_LOOKUP[k]: v for k, v in fields.items()}
+
+    issue.update(fields)

--- a/openedx_webhooks/lib/__init__.py
+++ b/openedx_webhooks/lib/__init__.py
@@ -1,0 +1,6 @@
+"""
+Reusable service providers.
+
+All of the subpackages and modules within this package should be reusable
+outside of this specific project.
+"""

--- a/openedx_webhooks/lib/edx_repo_tools_data/__init__.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tools to work with `edx/repo-tools-data`.
+"""

--- a/openedx_webhooks/lib/edx_repo_tools_data/models.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/models.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""
+edx/repo-tools-data related domain models.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from datetime import date
+
+import arrow
+
+from ..exceptions import NotFoundError
+
+
+class People(object):
+    """
+    Logical representation of `people.yaml`.
+
+    Attributes:
+        data (Dict[str, Any]): The raw dictionary as parsed from the
+            yaml file
+    """
+
+    def __init__(self, data):
+        """
+        Init.
+
+        Arguments:
+            data (Dict[str, Any]): The raw dictionary as parsed from
+                the yaml file
+        """
+        self.data = data
+
+    def get(self, key):
+        """
+        Get a specific person by `people.yaml` key.
+
+        Arguments:
+            key (str)
+
+        Returns:
+            openedx_webhooks.lib.edx_repo_tools_data.models.Person
+
+        Raises:
+            openedx_webhooks.lib.exceptions.NotFoundError: If key cannot
+                be found
+        """
+        person = self.data.get(key)
+
+        if not person:
+            raise NotFoundError("{} could not be found".format(key))
+
+        return Person(key, person)
+
+
+class Person(object):
+    """
+    Logical representation of an entry in `people.yaml`.
+
+    Attributes:
+        login (str): GitHub login
+        data (Dict[str, Any]): The raw dictionary as parsed from the
+            yaml file
+    """
+
+    # TODO: Test
+    def __init__(self, login, data):
+        """
+        Init.
+
+        Arguments:
+            login (str): GitHub login
+            data (Dict[str, Any]): The raw dictionary as parsed from
+                the yaml file
+        """
+        self.login = login
+        self.data = data
+
+    @property
+    def agreement(self):
+        """
+        Optional[str]: User's agreement.
+        """
+        data = self.data.get('agreement')
+        if data == 'none':
+            data = None
+        return data
+
+    @property
+    def agreement_expired(self):
+        """
+        bool: Has user's agreement expired.
+        """
+        expired = False
+        if self.agreement_expires_on:
+            expired = self.agreement_expires_on < date.today()
+        return expired
+
+    @property
+    def before(self):
+        """
+        Optional[Dict[str, Dict]]: User's `before` data.
+        """
+        return self.data.get('before')
+
+    @property
+    def agreement_expires_on(self):
+        """
+        Optional[datetime.date]: User's `before` data.
+        """
+        expires_on = self.data.get('expires_on')
+        if expires_on:
+            return expires_on
+
+        if not self.agreement:
+            # TODO: Is there a better way to handle this edge case?
+            #       Is it even possible to have no agreement and no
+            #       expiration data at all?
+            yesterday = arrow.now().replace(days=-1).date()
+            expires_on = yesterday
+
+        if not self.agreement and self.before:
+            expires_on = max(self.before.keys())
+
+        return expires_on
+
+    @property
+    def institution(self):
+        """
+        Optional[str]: User's institution.
+        """
+        data = self.data.get('institution')
+        return self.agreement and data
+
+    @property
+    def is_edx_user(self):
+        """
+        bool: Is user associated with edX.
+        """
+        if (
+                not self.agreement
+                or self.agreement_expired
+                or not self.institution
+        ):
+            return False
+        is_edx = self.institution.lower() == 'edx'
+        return is_edx

--- a/openedx_webhooks/lib/edx_repo_tools_data/utils.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/utils.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for working with `edx/repo-tools-data`.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from base64 import b64decode
+
+import yaml
+
+from ..github import gh
+from .models import People
+
+
+def get_people():
+    """
+    Fetch `people.yaml` from GitHub repo.
+
+    Returns:
+        openedx_webhooks.lib.edx_repo_tools_data.models.People
+    """
+    repo = gh.repository('edx', 'repo-tools-data')
+    raw = repo.contents('people.yaml').decoded
+    return People(yaml.safe_load(raw))

--- a/openedx_webhooks/lib/exceptions.py
+++ b/openedx_webhooks/lib/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Custom exceptions.
+"""
+
+class NotFoundError(Exception):
+    """
+    Something is not found.
+    """
+
+    pass

--- a/openedx_webhooks/lib/github/__init__.py
+++ b/openedx_webhooks/lib/github/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Tools to work with GitHub.
+
+This package also contains a special ``bin/`` directory, which has
+scripts to interact with GitHub.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from github3 import GitHub
+
+try:
+    from dotenv import find_dotenv, load_dotenv
+    load_dotenv(find_dotenv())
+except ImportError:
+    pass
+
+_token = os.getenv('GITHUB_PERSONAL_TOKEN')
+
+gh = GitHub(token=_token)
+"""
+(github3.GitHub): An authenticated GitHub API client session
+"""

--- a/openedx_webhooks/lib/github/bin/list_repos_with_webhook.py
+++ b/openedx_webhooks/lib/github/bin/list_repos_with_webhook.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+List all repos with specified webhook payload URL.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import click
+
+from openedx_webhooks.lib.github.utils import get_repos_with_webhook, repo_name
+
+click.disable_unicode_literals_warning = True
+
+
+@click.command()
+@click.argument('payload-url')
+@click.option(
+    '--exclude-inactive',
+    is_flag=True,
+    help="Include webhooks which aren't active"
+)
+def cli(payload_url, exclude_inactive):
+    """
+    List all repos with specified webhook payload URL.
+
+    Note that you must set the environment variable $GITHUB_PERSONAL_TOKEN
+    to a valid token that you create in GitHub.
+    """
+    repos = get_repos_with_webhook(payload_url, exclude_inactive)
+
+    for repo in repos:
+        click.echo(repo_name(repo))
+
+
+if __name__ == '__main__':
+    cli()

--- a/openedx_webhooks/lib/github/bin/update_or_create_webhooks.py
+++ b/openedx_webhooks/lib/github/bin/update_or_create_webhooks.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Update or create webhooks according to spec.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+
+import click
+from openedx_webhooks.lib.github.utils import update_or_create_webhook
+
+click.disable_unicode_literals_warning = True
+
+
+@click.command()
+@click.argument('config-json', type=click.File('rb'))
+@click.option('--dry-run', is_flag=True)
+def cli(config_json, dry_run):
+    """
+    Update or create webhooks according to spec.
+
+    Using a configuration file, create or update webhooks in specified repos.
+
+    \b
+    {
+      "repos": [
+        "owner1/repo1",
+        ...
+      ],
+      "hooks": [
+        {
+          "config": {
+            "url": "payload_url",
+            "insecure_ssl": false, # Optional
+            "secret": "secret", # Optional
+            "content_type": "json" # Optional
+          },
+          "events": [
+            "pull_request",
+            ...
+          ]
+        },
+        ...
+      ]
+    }
+
+    See <https://developer.github.com/v3/repos/hooks/#create-a-hook> for
+    more information about the `config`.
+
+    Note that you must set the environment variable $GITHUB_PERSONAL_TOKEN
+    to a valid token that you create in GitHub.
+    """
+    raw = json.load(config_json)
+    repos = raw['repos']
+    hook_confs = raw['hooks']
+
+    if dry_run:
+        click.echo(
+            '**Dry run only** The following actions would have been performed:'
+        )
+
+    for repo in repos:
+        for conf in hook_confs:
+            active = conf.get('active', True)
+            config = conf['config']
+            events = conf['events']
+            url = config['url']
+
+            hook, created, deleted = update_or_create_webhook(
+                repo, config, events, active, dry_run
+            )
+            if created:
+                msg = "{} webhook created: {}".format(repo, url)
+            else:
+                msg = "{} webhook({}) updated: {}".format(repo, hook.id, url)
+            click.echo(msg)
+
+            for d in deleted:
+                msg = "{} webhook({}) deleted: {}".format(repo, d.id, url)
+                click.echo(msg)
+
+
+if __name__ == '__main__':
+    cli()

--- a/openedx_webhooks/lib/github/models.py
+++ b/openedx_webhooks/lib/github/models.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Generic GitHub domain models.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import arrow
+
+
+class GithubWebHookRequestHeader(object):
+    """
+    Represent a GitHub webhook request header.
+
+    Attributes:
+        headers (flask.Request.headers): HTTP headers as received by Flask
+    """
+
+    def __init__(self, headers):
+        """
+        Init.
+
+        Arguments:
+            headers (flask.Request.headers): HTTP headers as received by Flask
+        """
+        self.headers = headers
+
+    @property
+    def event_type(self):
+        """
+        str: The webhook event type.
+        """
+        return self.headers.get('X-Github-Event')
+
+    @property
+    def signature(self):
+        """
+        str: Hash signature of the payload.
+        """
+        return self.headers.get('X-Hub-Signature')
+
+
+class GithubWebHookEvent(object):
+    """
+    A GitHub webhook event.
+
+    Attributes:
+        event_type (str): GitHub event type
+        event (Dict[str, Any]): The parsed event payload
+    """
+
+    # TODO: Test
+    def __init__(self, event_type, event):
+        """
+        Init.
+
+        Arguments:
+            event_type (str): GitHub event type
+            event (Dict[str, Any]): The parsed event payload
+        """
+        self.event_type = event_type
+        self.event = event
+
+    @property
+    def _event_resource(self):
+        """
+        str: GitHub reource type, such as 'pull_request' or 'issue'.
+        """
+        keys = ('pull_request', 'issue')
+        try:
+            return next((k for k in keys if self.event_type.startswith(k)))
+        except StopIteration:
+            return self.event_type
+
+    @property
+    def action(self):
+        """
+        str: The action of the event.
+        """
+        return self.event['action']
+
+    @property
+    def description(self):
+        """
+        str: Description of the event.
+        """
+        return "{}: {}".format(self.event_type, self.action)
+
+    @property
+    def html_url(self):
+        """
+        str: URL of the GitHub resource that the event is about.
+        """
+        return self.event[self._event_resource]['html_url']
+
+    @property
+    def sender_login(self):
+        """
+        str: GitHub login of the user who sent the event.
+        """
+        return self.event['sender']['login']
+
+    @property
+    def updated_at(self):
+        """
+        datetime.datetime: Datetime of the event.
+        """
+        dt = self.event[self._event_resource]['updated_at']
+        return arrow.get(dt).datetime

--- a/openedx_webhooks/lib/github/utils.py
+++ b/openedx_webhooks/lib/github/utils.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for working with GitHub.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from openedx_webhooks.lib.github import gh
+
+
+def _get_most_recent_hook(hooks):
+    """
+    Return the most recent hook.
+
+    Most recent is defined by active status, then updated datetime.
+    This means active hooks will be prioritized over inactive ones,
+    no matter what the updated datetimes are.
+
+    Arguments:
+        hooks (Iterable[github3.repos.hook.Hook])
+
+    Returns:
+        Optional(github3.repos.hook.Hook)
+    """
+    # TODO: Test
+    try:
+        return max(hooks, key=lambda h: (h.active, h.updated_at))
+    except ValueError:
+        return None
+
+
+def repo_name(repo):
+    """
+    Construct the repo name.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+
+    Returns:
+        str
+    """
+    return "{0.owner.login}/{0.name}".format(repo)
+
+
+def create_hook(repo, config, events, active, dry_run=False):
+    """
+    Create a webhook in the specified repo.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        config (Dict[str, str]): key-value pairs which act as settings
+            for this hook
+        events (List[str]): events the hook is triggered for
+        active (bool): whether the hook is actually triggered
+        dry_run (bool): Don't really create the hook
+
+    Returns:
+        (Optional[github3.repos.hook.Hook])
+
+    Raises:
+        Exception: If the hook can't be created for some reason
+    """
+    if dry_run:
+        return None
+    hook = repo.create_hook('web', config, events, active)
+    if not hook:
+        raise Exception("Can't create {} webhook: {}".format(
+            repo_name(repo), config['url']
+        ))
+    return hook
+
+
+def edit_hook(repo, hook, config, events, active, dry_run=False):
+    """
+    Edit a webhook in the specified repo.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        hook (github3.repos.hook.Hook)
+        config (Dict[str, str]): key-value pairs which act as settings
+            for this hook
+        events (List[str]): events the hook is triggered for
+        active (bool): whether the hook is actually triggered
+        dry_run (bool): Don't really edit the hook
+
+    Returns:
+        github3.repos.hook.Hook: The updated hook object
+
+    Raises:
+        Exception: If the hook can't be edited for some reason
+    """
+    if dry_run:
+        return hook
+    result = hook.edit(config, events, active=active)
+    if not result:
+        raise Exception("Can't edit {} webhook({}): {}".format(
+            repo_name(repo), hook.id, hook.config['url']
+        ))
+    updated_hook = repo.hook(hook.id)
+    return updated_hook
+
+
+def delete_hook(repo, hook, dry_run=False):
+    """
+    Delete a webhook in the specified repo.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        hook (github3.repos.hook.Hook)
+        dry_run (bool): Don't really delete the hook
+
+    Raises:
+        Exception: If the hook can't be deleted for some reason
+    """
+    if dry_run:
+        return
+    result = hook.delete()
+    if not result:
+        raise Exception("Can't delete {} webhook({}): {}".format(
+            repo_name(repo), hook.id, hook.config['url']
+        ))
+
+
+def delete_hooks(repo, hooks, dry_run=False):
+    """
+    Delete webhooks in the specified repo.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        hooks (List[github3.repos.hook.Hook])
+        dry_run (bool): Don't really delete the hook
+    """
+    if not dry_run:
+        for hook in hooks:
+            delete_hook(repo, hook, dry_run)
+
+
+def get_webhooks(repo, payload_url):
+    """
+    Get webhooks installed in a given repo that match the payload_url.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        payload_url (str): The webhook payload URL, this acts as the key
+            of the webhooks
+
+    Returns:
+        Iterator[github3.repos.hook.Hook]
+    """
+    # TODO: Test
+    hooks = (
+        h for h in repo.iter_hooks()
+        if h.name == 'web' and h.config['url'] == payload_url
+    )
+    return hooks
+
+
+def repo_contains_webhook(repo, payload_url, exclude_inactive=False):
+    """
+    Determine whether a repo contains webhooks with the specified payload_url.
+
+    Arguments:
+        repo (github3.repos.repo.Repository)
+        payload_url (str): The webhook payload URL, this acts as the key
+            of the webhooks
+        exclude_inactive (bool): Exclude inactive webhooks from the result
+
+    Returns:
+        bool
+    """
+    # TODO: Test
+    hooks = get_webhooks(repo, payload_url)
+    is_active_list = [h.active for h in hooks]
+    is_active = any(is_active_list)
+    if is_active_list and (is_active or not exclude_inactive):
+        return True
+    return False
+
+
+def get_repos_with_webhook(payload_url, exclude_inactive=False):
+    """
+    Find repos that contain webhooks with the specified payload_url.
+
+    Arguments:
+        payload_url (str): The webhook payload URL, this acts as the key
+            of the webhooks
+        exclude_inactive (bool): Exclude inactive webhooks from the result
+
+    Returns:
+        Iterator[github3.repos.repo.Repository]
+    """
+    for repo in gh.iter_repos():
+        if repo_contains_webhook(repo, payload_url, exclude_inactive):
+            yield repo
+
+
+def update_or_create_webhook(
+        repo_name, config, events, active=True, dry_run=False
+):
+    """
+    Update or create webhook in repo.
+
+    Arguments:
+        repo_name (str)
+        config (Dict[str, str]): key-value pairs which act as settings
+            for this hook
+        events (List[str]): events the hook is triggered for
+        active (bool): whether the hook is actually triggered
+        dry_run (bool): Don't really create the hook
+
+    Returns:
+        Tuple[
+            Optional[github3.repos.hook.Hook],
+            bool,
+            List[github3.repos.hook.Hook]
+        ]: Returns (
+            the created or updated hook,
+            ``True`` if created, ``False`` if edited,
+            a list of hooks deleted (if any)
+        )
+    """
+    repo = gh.repository(*repo_name.split('/'))
+    payload_url = config['url']
+
+    existing_hooks = list(get_webhooks(repo, payload_url))
+
+    if existing_hooks:
+        hook_to_edit = _get_most_recent_hook(existing_hooks)
+        hooks_to_delete = list(existing_hooks)
+        hooks_to_delete.remove(hook_to_edit)
+
+        hook = edit_hook(repo, hook_to_edit, config, events, active, dry_run)
+        delete_hooks(repo, hooks_to_delete, dry_run)
+        created = False
+    else:
+        hooks_to_delete = []
+        hook = create_hook(repo, config, events, active, dry_run)
+        created = True
+
+    return hook, created, hooks_to_delete

--- a/openedx_webhooks/lib/jira/__init__.py
+++ b/openedx_webhooks/lib/jira/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Tools to work with JIRA.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from base64 import b64decode
+import os
+
+from jira import JIRA
+
+_server = os.environ.get('JIRA_SERVER')
+_oauth_info = dict(
+    access_token=os.environ.get('JIRA_ACCESS_TOKEN'),
+    access_token_secret=os.environ.get('JIRA_ACCESS_TOKEN_SECRET'),
+    consumer_key=os.environ.get('JIRA_OAUTH_CONSUMER_KEY'),
+    key_cert=b64decode(os.environ.get('JIRA_OAUTH_PRIVATE_KEY')),
+)
+
+jira = JIRA(_server, oauth=_oauth_info)
+"""
+(jira.JIRA): An authenticated JIRA API client session
+"""

--- a/openedx_webhooks/lib/jira/models.py
+++ b/openedx_webhooks/lib/jira/models.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+Generic JIRA domain models.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..exceptions import NotFoundError
+
+
+class JiraFields(object):
+    """
+    Represent a collection of JIRA fields.
+    """
+
+    # TODO: Test
+    def __init__(self, data):
+        """
+        Init.
+
+        Arguments:
+            data (List[Dict[str, Any]]): Raw data of the fields
+        """
+        self._data = data
+
+    def get_by_name(self, name):
+        """
+        Find a field by name.
+
+        Arguments:
+            name (str)
+
+        Returns:
+            openedx_webhooks.lib.jira.models.JiraField
+
+        Raises:
+            openedx_webhooks.lib.exceptions.NotFoundError
+        """
+        # TODO: It's possible to have two fields by the same name in JIRA,
+        #       we're only returning the first one found!
+        results = [f for f in self._data if f['name'] == name]
+
+        if not results:
+            raise NotFoundError("{} could not be found".format(name))
+
+        return JiraField(results[0])
+
+
+class JiraField(object):
+    """
+    Represent a JIRA field.
+
+    Attributes:
+        All attributes are delegated to ``self._data``. If a key exists,
+        the the attribute is returned.
+    """
+
+    def __init__(self, data):
+        """
+        Init.
+
+        Arguments:
+            data (Dict[str, Any]): Raw data of the field.
+        """
+        self._data = data
+
+    def __getattr__(self, attr):
+        """
+        Return attribute based on self._data[key].
+
+        Arguments:
+            attr (str)
+
+        Returns:
+            Any: self._data[key]
+
+        Raises:
+            AttributeError
+        """
+        try:
+            return self._data[attr]
+        except KeyError:
+            msg = "'{}' object has no attribute '{}'".format(
+                self.__class__.__name__, attr
+            )
+            raise AttributeError(msg)

--- a/openedx_webhooks/lib/jira/utils.py
+++ b/openedx_webhooks/lib/jira/utils.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for working with JIRA.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import arrow
+
+from . import jira
+from .models import JiraFields
+
+
+def convert_to_jira_datetime_string(dt):
+    """
+    Convert a datetime to format expected by JIRA's API.
+
+    For example: ``'2016-10-23T08:22:54.706-0700'``
+
+    Arguments:
+        dt (datetime.datetime)
+
+    Returns:
+        str
+    """
+    # TODO: Test
+    return arrow.get(dt).format('YYYY-MM-DDTHH:mm:ss.SSSZ')
+
+
+def find_allowed_values(project_key, issue_type_name, field_name, jira=jira):
+    """
+    Find allowed values for a given JIRA field.
+
+    Certain JIRA field types (such as Radio Buttons) have enumerated
+    allowed values. This function retrieves those values in a format
+    which can used to set the value for that field while creating or
+    editing an issue.
+
+    Arguments:
+        project_key (str): The JIRA project key
+        issue_type_name (str): Name of the issue type within the project
+        field_name (str): Name of the field within the issue type
+        jira (jira.JIRA): An authenticated JIRA API client session
+
+    Returns:
+        List[Dict[str, str]]: List of allowed values in JIRA spec format
+    """
+    meta = jira.createmeta(
+        project_key,
+        issuetypeNames=issue_type_name,
+        expand='projects.issuetypes.fields',
+    )
+    fields = meta['projects'][0]['issuetypes'][0]['fields']
+    field_id = make_fields_lookup([field_name])[field_name]
+    return fields[field_id]['allowedValues']
+
+
+def make_fields_lookup(names=[], jira=jira):
+    """
+    Make a map of JIRA field names to IDs.
+
+    Arguments:
+        names (List[str]): List of field names we want to look up
+        jira (jira.JIRA): An authenticated JIRA API client session
+
+    Returns:
+        Dict[str, str]: {field_name: field_id, ...}
+    """
+    # TODO: Test
+    fields = JiraFields(jira.fields())
+    lookup = {}
+    for name in names:
+        field = fields.get_by_name(name)
+        lookup[field.name] = field.id
+    return lookup

--- a/openedx_webhooks/lib/rq.py
+++ b/openedx_webhooks/lib/rq.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+RQ tools.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from rq import Queue
+import redis
+
+_redis_url = os.getenv('REDIS_URL', 'redis://')
+
+store = redis.from_url(_redis_url)
+"""
+redis.Redis: Instance of a connected Redis store
+"""
+
+q = Queue(connection=store)
+"""
+rq.Queue: Instance of RQ queue
+"""

--- a/openedx_webhooks/utils.py
+++ b/openedx_webhooks/utils.py
@@ -1,13 +1,40 @@
 # coding=utf-8
+"""
+Generic utilities.
+"""
+
 from __future__ import print_function, unicode_literals
 
+from hashlib import sha1
+import hmac
 import os
 import sys
 
 from flask import request
+from urlobject import URLObject
 import functools32
 import requests
-from urlobject import URLObject
+
+
+def is_valid_payload(secret, signature, payload):
+    """
+    Ensure payload is valid according to signature.
+
+    Make sure the payload hashes to the signature as calculated using
+    the shared secret.
+
+    Arguments:
+        secret (str): The shared secret
+        signature (str): Signature as calculated by the server, sent in
+            the request
+        payload (str): The request payload
+
+    Returns:
+        bool: Is the payload legit?
+    """
+    mac = hmac.new(str(secret), msg=payload, digestmod=sha1)
+    digest = 'sha1=' + mac.hexdigest()
+    return hmac.compare_digest(str(digest), str(signature))
 
 
 def pop_dict_id(d):

--- a/openedx_webhooks/webhook_confs.py
+++ b/openedx_webhooks/webhook_confs.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Configuration for webhooks we want to install.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from flask import url_for
+
+
+WEBHOOK_CONFS = [{
+    'config': {
+        'url': url_for("github_views.pull_request", _external=True),
+        'content_type': 'json',
+        'insecure_ssl': False,
+    },
+    'events': ['pull_request']
+}]
+"""
+List[Dict[str, Any]]: A list of GitHub webhook configurations. Currently
+    we use these configurations to create webhooks in the specified GitHub
+    repo. Each configuration expects the following keys:
+
+-  config (Dict[str, Any]): See `GitHub documentation`_ for more details
+   on possible keys and values.
+-  events (List[str]): See `list of possible events`_.
+
+.. _GitHub documentation: https://developer.github.com/v3/repos/hooks/#create-a-hook
+.. _list of possible events: https://developer.github.com/webhooks/#events
+"""

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,17 +7,23 @@ Flask-Script
 Flask==0.10.1
 PyYAML
 URLObject
+arrow
 blinker
 celery
+click
 cryptography
 functools32
+github3.py>=0.9,<1.0
 gunicorn
 iso8601
+jira
 oauthlib[signedtoken]
 psycopg2
 raven
 redis
 requests
 requests-oauthlib
+rq
+
 # rabbitmq is giving us problems, so lets try ironmq
 iron_celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,10 +6,12 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+arrow==0.8.0
 billiard==3.3.0.23        # via celery
 blinker==1.4
-celery==3.1.23
+celery==3.1.24
 cffi==1.8.3               # via cryptography
+click==6.6
 contextlib2==0.5.4        # via raven
 cryptography==1.5.2
 enum34==1.1.6             # via cryptography
@@ -19,6 +21,7 @@ Flask-SQLAlchemy==2.0
 Flask-SSLify==0.1.5
 Flask==0.10.1             # via flask-dance, flask-script, flask-sqlalchemy, flask-sslify
 functools32==3.2.3.post2
+github3.py==0.9.6
 gunicorn==19.6.0
 idna==2.1                 # via cryptography
 ipaddress==1.0.17         # via cryptography
@@ -29,24 +32,30 @@ iron-mq==0.9              # via iron-celery
 iso8601==0.1.11
 itsdangerous==0.24        # via flask
 Jinja2==2.8               # via flask
-kombu==3.0.35             # via celery
+jira==1.0.7
+kombu==3.0.37             # via celery
 lazy==1.2                 # via flask-dance
 MarkupSafe==0.23          # via jinja2
 oauthlib[signedtoken]==2.0.0
 psycopg2==2.6.2
 pyasn1==0.1.9             # via cryptography
-pycparser==2.14           # via cffi
+pycparser==2.16           # via cffi
 pyjwt==1.4.2              # via oauthlib
-python-dateutil==2.5.3    # via iron-core
-pytz==2016.6.1            # via celery
+python-dateutil==2.5.3    # via arrow, iron-core
+pytz==2016.7              # via celery
 PyYAML==3.12
-raven==5.27.1
+raven==5.31.0
 redis==2.10.5
 requests-oauthlib==0.7.0
+requests-toolbelt==0.7.0  # via jira
 requests==2.11.1
-six==1.10.0               # via cryptography, flask-dance, python-dateutil, sqlalchemy-utils
+rq==0.6.0
+six==1.10.0               # via cryptography, flask-dance, jira, python-dateutil, sqlalchemy-utils
 sqlalchemy-utils==0.32.9  # via flask-dance
-SQLAlchemy==1.0.15        # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+SQLAlchemy==1.1.2         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+tlslite==0.4.9            # via jira
+uritemplate.py==3.0.2     # via github3.py
+uritemplate==3.0.0        # via uritemplate.py
 URLObject==2.4.2          # via flask-dance
 Werkzeug==0.11.11         # via flask
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,3 +2,4 @@
 
 edx-lint                  # For updating pylintrc
 pip-tools                 # Requirements file management
+python-dotenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
-click==6.6                # via pip-tools
+click==6.6                # via pip-tools, python-dotenv
 colorama==0.3.7           # via pylint
 edx-lint==0.5.1
 first==2.0.1              # via pip-tools
@@ -15,5 +15,6 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+python-dotenv==0.6.0
 six==1.10.0               # via astroid, edx-lint, pip-tools, pylint
 wrapt==1.10.8             # via astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,10 +13,10 @@ imagesize==0.7.1          # via sphinx
 Jinja2==2.8               # via sphinx
 MarkupSafe==0.23          # via jinja2
 Pygments==2.1.3           # via readme-renderer, sphinx
-pytz==2016.6.1            # via babel
+pytz==2016.7              # via babel
 readme-renderer==0.7.0
 six==1.10.0               # via bleach, html5lib, readme-renderer, sphinx, sphinxcontrib-httpdomain
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.1.9
-Sphinx==1.4.6             # via sphinx-rtd-theme, sphinxcontrib-httpdomain
+Sphinx==1.4.8             # via sphinx-rtd-theme, sphinxcontrib-httpdomain
 sphinxcontrib-httpdomain==1.5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,13 +8,15 @@ alabaster==0.7.9          # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 argparse==1.4.0           # via codecov
+arrow==0.8.0
 babel==2.3.4              # via sphinx
 betamax==0.8.0
 billiard==3.3.0.23        # via celery
 bleach==1.4.3             # via readme-renderer
 blinker==1.4
-celery==3.1.23
+celery==3.1.24
 cffi==1.8.3               # via cryptography
+click==6.6
 codecov==2.0.5
 contextlib2==0.5.4        # via raven
 coverage==4.2             # via codecov, pytest-cov
@@ -28,6 +30,7 @@ Flask-SSLify==0.1.5
 Flask==0.10.1             # via flask-dance, flask-script, flask-sqlalchemy, flask-sslify
 funcsigs==1.0.2           # via mock
 functools32==3.2.3.post2
+github3.py==0.9.6
 gunicorn==19.6.0
 html5lib==0.9999999       # via bleach
 idna==2.1                 # via cryptography
@@ -40,7 +43,8 @@ iron-mq==0.9              # via iron-celery
 iso8601==0.1.11
 itsdangerous==0.24        # via flask
 Jinja2==2.8               # via flask, sphinx
-kombu==3.0.35             # via celery
+jira==1.0.7
+kombu==3.0.37             # via celery
 lazy==1.2                 # via flask-dance
 MarkupSafe==0.23          # via jinja2
 mock==2.0.0               # via pytest-mock
@@ -49,28 +53,33 @@ pbr==1.10.0               # via mock
 psycopg2==2.6.2
 py==1.4.31                # via pytest
 pyasn1==0.1.9             # via cryptography
-pycparser==2.14           # via cffi
+pycparser==2.16           # via cffi
 Pygments==2.1.3           # via readme-renderer, sphinx
 pyjwt==1.4.2              # via oauthlib
-pytest-cov==2.3.1
+pytest-cov==2.4.0
 pytest-mock==1.2
-pytest==3.0.2
-python-dateutil==2.5.3    # via iron-core
-pytz==2016.6.1            # via babel, celery
+pytest==3.0.3
+python-dateutil==2.5.3    # via arrow, iron-core
+pytz==2016.7              # via babel, celery
 PyYAML==3.12
-raven==5.27.1
+raven==5.31.0
 readme-renderer==0.7.0
 redis==2.10.5
 requests-mock==1.1.0
 requests-oauthlib==0.7.0
+requests-toolbelt==0.7.0  # via jira
 requests==2.11.1
-six==1.10.0               # via bleach, cryptography, flask-dance, html5lib, mock, python-dateutil, readme-renderer, requests-mock, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
+rq==0.6.0
+six==1.10.0               # via bleach, cryptography, flask-dance, html5lib, jira, mock, python-dateutil, readme-renderer, requests-mock, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.1.9
-Sphinx==1.4.6             # via sphinx-rtd-theme, sphinxcontrib-httpdomain
+Sphinx==1.4.8             # via sphinx-rtd-theme, sphinxcontrib-httpdomain
 sphinxcontrib-httpdomain==1.5.0
 sqlalchemy-utils==0.32.9  # via flask-dance
-sqlalchemy==1.0.15        # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+sqlalchemy==1.1.2         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+tlslite==0.4.9            # via jira
+uritemplate.py==3.0.2     # via github3.py
+uritemplate==3.0.0        # via uritemplate.py
 URLObject==2.4.2          # via flask-dance
 Werkzeug==0.11.11         # via flask
 

--- a/rq_worker.py
+++ b/rq_worker.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Start an instance of the RQ worker.
+
+``python rq_worker.py``
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from rq import Connection, Queue, Worker
+
+from openedx_webhooks.lib.rq import store
+
+
+LISTEN = ('default',)
+
+
+if __name__ == '__main__':
+    logging_level = os.environ.get('RQ_WORKER_LOGGING_LEVEL', 'INFO').upper()
+    with Connection(store):
+        worker = Worker(map(Queue, LISTEN))
+        worker.work(logging_level=logging_level)


### PR DESCRIPTION
## Highlights

* Listen for the following GitHub PR events, and post updates to JIRA issues accordingly:
    * issue_comment
    * pull_request
    * pull_request_review
    * pull_request_review_comment
* Establish a new pattern for the bot:
    * Flask views do not need to know how to access GitHub and JIRA.
    * OAuth credentials are stored in environment variables, not in the database.
    * Flask views and asynchronous tasks do not share bootstrap process and environments.
    * Use [RQ](http://python-rq.org) instead of Celery for job queueing and processing.
    
    The general workflow is `views` → `dispatcher` → `tasks`.
    
## Deployment

When you’re ready for deployment, follow the steps in the HOWTO-activate-jira-github-activity.rst.

/cc @edx/ospr @wesmason @kylecrawshaw 