### PR TITLE
Lock down Celery version

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,7 +9,7 @@ PyYAML
 URLObject
 arrow
 blinker
-celery
+celery>=3,<4
 click
 cryptography
 functools32

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,11 +9,11 @@ anyjson==0.3.3            # via kombu
 arrow==0.8.0
 billiard==3.3.0.23        # via celery
 blinker==1.4
-celery==3.1.24
+celery==3.1.25
 cffi==1.8.3               # via cryptography
 click==6.6
 contextlib2==0.5.4        # via raven
-cryptography==1.5.2
+cryptography==1.5.3
 enum34==1.1.6             # via cryptography
 Flask-Dance[sqla]==0.8.2
 Flask-Script==2.0.5
@@ -52,7 +52,7 @@ requests==2.11.1
 rq==0.6.0
 six==1.10.0               # via cryptography, flask-dance, jira, python-dateutil, sqlalchemy-utils
 sqlalchemy-utils==0.32.9  # via flask-dance
-SQLAlchemy==1.1.3         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+sqlalchemy==1.1.3         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
 tlslite==0.4.9            # via jira
 uritemplate.py==3.0.2     # via github3.py
 uritemplate==3.0.0        # via uritemplate.py

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.9          # via sphinx
 babel==2.3.4              # via sphinx
-bleach==1.4.3             # via readme-renderer
+bleach==1.5.0             # via readme-renderer
 docutils==0.12            # via readme-renderer, sphinx
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,15 +12,15 @@ arrow==0.8.0
 babel==2.3.4              # via sphinx
 betamax==0.8.0
 billiard==3.3.0.23        # via celery
-bleach==1.4.3             # via readme-renderer
+bleach==1.5.0             # via readme-renderer
 blinker==1.4
-celery==3.1.24
+celery==3.1.25
 cffi==1.8.3               # via cryptography
 click==6.6
 codecov==2.0.5
 contextlib2==0.5.4        # via raven
 coverage==4.2             # via codecov, pytest-cov
-cryptography==1.5.2
+cryptography==1.5.3
 docutils==0.12            # via readme-renderer, sphinx
 enum34==1.1.6             # via cryptography
 Flask-Dance[sqla]==0.8.2
@@ -57,7 +57,7 @@ pycparser==2.17           # via cffi
 Pygments==2.1.3           # via readme-renderer, sphinx
 pyjwt==1.4.2              # via oauthlib
 pytest-cov==2.4.0
-pytest-mock==1.3.0
+pytest-mock==1.4.0
 pytest==3.0.3
 python-dateutil==2.5.3    # via arrow, iron-core
 pytz==2016.7


### PR DESCRIPTION
Celery 4 is out and isn't compatible with our code.

/cc @edx/ospr 