### PR TITLE
Handle robot and unknown person PR activities

### DIFF
--- a/openedx_webhooks/github/dispatcher/rules/github_activity.py
+++ b/openedx_webhooks/github/dispatcher/rules/github_activity.py
@@ -6,6 +6,8 @@ Update JIRA issue with latest GitHub activity.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from ....jira.tasks import update_latest_github_activity
+from ....lib.exceptions import NotFoundError
+from ....lib.github.decorators import inject_gh
 from ....lib.jira.decorators import inject_jira
 from ...models import GithubEvent
 
@@ -25,26 +27,47 @@ def _find_issues_for_pull_request(jira, pull_request_url):
     return jira.search_issues(jql)
 
 
-def _process(jira, event_type, raw_event):
+def _is_sender_edx_user(event):
+    """
+    Determine if event sender is an edX user.
+
+    Arguments:
+        event (openedx_webhooks.github.models.GithubEvent)
+
+    Returns:
+        bool
+    """
+    try:
+        return event.sender.is_edx_user
+    except NotFoundError:
+        return False
+
+
+@inject_gh
+def _process(gh, jira, event_type, raw_event):
     """
     Update each corresponding JIRA issue with GitHub activity.
 
     Arguments:
+        gh (github3.GitHub): An authenticated GitHub API client session
         jira (jira.JIRA): An authenticated JIRA API client session
         event_type (str): GitHub event type
         raw_event (Dict[str, Any]): The parsed event payload
     """
-    event = GithubEvent(event_type, raw_event)
-    issues = _find_issues_for_pull_request(jira, event.html_url)
-    for issue in issues:
-        update_latest_github_activity(
-            jira,
-            issue.id,
-            event.description,
-            event.user.login,
-            event.updated_at,
-            event.is_edx_user,
-        )
+    event = GithubEvent(gh, event_type, raw_event)
+    if not event.sender.is_robot:
+        issues = _find_issues_for_pull_request(jira, event.html_url)
+        is_edx_user = _is_sender_edx_user(event)
+
+        for issue in issues:
+            update_latest_github_activity(
+                jira,
+                issue.id,
+                event.description,
+                event.sender_login,
+                event.updated_at,
+                is_edx_user,
+            )
 
 
 @inject_jira

--- a/openedx_webhooks/github/models.py
+++ b/openedx_webhooks/github/models.py
@@ -14,36 +14,27 @@ class GithubEvent(GithubWebHookEvent):
     A GitHub webhook event.
 
     Attributes:
+        gh (github3.GitHub): An authenticated GitHub API client session
         event_type (str): GitHub event type
         event (Dict[str, Any]): The parsed event payload
-        get_people (Callable[[], ..lib.edx_repo_tools_data.models.People]):
-            Function used to get `people.yaml` folks
     """
 
-    def __init__(self, event_type, event, get_people=get_people):
+    def __init__(self, gh, event_type, event):
         """
         Init.
 
         Arguments:
+            gh (github3.GitHub): An authenticated GitHub API client session
             event_type (str): GitHub event type
             event (Dict[str, Any]): The parsed event payload
-            get_people (Callable[[], ..lib.edx_repo_tools_data.models.People]):
-                Function used to get `people.yaml` folks
         """
         super(GithubEvent, self).__init__(event_type, event)
-        self.get_people = get_people
+        self.gh = gh
 
     @property
-    def is_edx_user(self):
-        """
-        bool: Is the user who sent the event part of edX.
-        """
-        return self.user.is_edx_user
-
-    @property
-    def user(self):
+    def sender(self):
         """
         openedx_webhooks.lib.edx_repo_tools_data.models.Person: Activity user.
         """
-        people = self.get_people()
+        people = get_people(self.gh)
         return people.get(self.sender_login)

--- a/openedx_webhooks/lib/edx_repo_tools_data/models.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/models.py
@@ -17,7 +17,7 @@ class People(object):
     Logical representation of `people.yaml`.
 
     Attributes:
-        data (Dict[str, Any]): The raw dictionary as parsed from the
+        _data (Dict[str, Any]): The raw dictionary as parsed from the
             yaml file
     """
 
@@ -58,9 +58,9 @@ class Person(object):
     Logical representation of an entry in `people.yaml`.
 
     Attributes:
-        login (str): GitHub login
-        data (Dict[str, Any]): The raw dictionary as parsed from the
+        _data (Dict[str, Any]): The raw dictionary as parsed from the
             yaml file
+        login (str): GitHub login
     """
 
     def __init__(self, login, data):

--- a/openedx_webhooks/lib/edx_repo_tools_data/models.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/models.py
@@ -144,3 +144,10 @@ class Person(object):
             return False
         is_edx = self.institution.lower() == 'edx'
         return is_edx
+
+    @property
+    def is_robot(self):
+        """
+        bool: Is the user a robot?
+        """
+        return self._data.get('is_robot', False)

--- a/openedx_webhooks/lib/edx_repo_tools_data/test/models/conftest.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/test/models/conftest.py
@@ -7,28 +7,20 @@ import pytest
 
 from openedx_webhooks.lib.edx_repo_tools_data.models import People, Person
 
+ACTIVE_DATA = {'active-person': {
+    'agreement': 'individual',
+}}
 
-@pytest.fixture
-def active_data():
-    data = {'active-person': {
-        'agreement': 'individual',
-    }}
-    return data
-
-
-@pytest.fixture
-def expired_data():
-    data = {'expired-person': {
-        'agreement': 'institution',
-        'expires_on': datetime.date(2012, 10, 1),
-        'institution': 'edX',
-    }}
-    return data
+EXPIRED_DATA = {'expired-person': {
+    'agreement': 'institution',
+    'expires_on': datetime.date(2012, 10, 1),
+    'institution': 'edX',
+}}
 
 
 @pytest.fixture
-def active_person(active_data):
-    k, v = list(active_data.items())[0]
+def active_person():
+    k, v = list(ACTIVE_DATA.items())[0]
     return Person(k, v)
 
 
@@ -51,8 +43,8 @@ def active_non_edx_person():
 
 
 @pytest.fixture
-def expired_person(expired_data):
-    k, v = list(expired_data.items())[0]
+def expired_person():
+    k, v = list(EXPIRED_DATA.items())[0]
     return Person(k, v)
 
 
@@ -76,7 +68,7 @@ def before_expired_person(before):
 
 
 @pytest.fixture
-def people(active_data, expired_data):
-    data = active_data.copy()
-    data.update(expired_data)
+def people():
+    data = ACTIVE_DATA.copy()
+    data.update(EXPIRED_DATA)
     return People(data)

--- a/openedx_webhooks/lib/edx_repo_tools_data/test/models/test_person.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/test/models/test_person.py
@@ -76,3 +76,14 @@ class TestIsEdxUser:
 
     def test_another_institution(self, active_non_edx_person):
         assert active_non_edx_person.is_edx_user is False
+
+
+class TestIsRobot:
+    def test_true(self):
+        person = Person('robot', {
+            'is_robot': True
+        })
+        assert person.is_robot is True
+
+    def test_false(self, active_person):
+        assert active_person.is_robot is False

--- a/openedx_webhooks/lib/jira/models.py
+++ b/openedx_webhooks/lib/jira/models.py
@@ -18,7 +18,7 @@ class JiraFields(object):
         Init.
 
         Arguments:
-            data (List[Dict[str, Any]]): Raw data of the fields
+            _data (List[Dict[str, Any]]): Raw data of the fields
         """
         self._data = data
 

--- a/openedx_webhooks/lib/jira/utils.py
+++ b/openedx_webhooks/lib/jira/utils.py
@@ -53,7 +53,7 @@ def find_allowed_values(jira, project_key, issue_type_name, field_name):
         expand='projects.issuetypes.fields',
     )
     fields = meta['projects'][0]['issuetypes'][0]['fields']
-    field_id = make_fields_lookup([field_name])[field_name]
+    field_id = make_fields_lookup(jira, [field_name])[field_name]
     return fields[field_id]['allowedValues']
 
 


### PR DESCRIPTION
1. Ignore incoming events from known bots (entries with `is_robot: true` in `people.yaml`).
2. For users not in `people.yaml` assume they are not edX users but still process the event.

/cc @edx/ospr 