### PR TITLE
Removing AUTHORS line from PR comments

### DIFF
--- a/openedx_webhooks/tasks/github.py
+++ b/openedx_webhooks/tasks/github.py
@@ -364,7 +364,6 @@ def github_community_pr_comment(pull_request, jira_issue, people=None):
 
     * contain a link to the JIRA issue
     * check for contributor agreement
-    * check for AUTHORS entry
     * contain a link to our process documentation
     """
     github = github_bp.session
@@ -377,27 +376,12 @@ def github_community_pr_comment(pull_request, jira_issue, people=None):
         pr_author in people and
         people[pr_author].get("expires_on", date.max) > created_at.date()
     )
-    # is the user in the AUTHORS file?
-    in_authors_file = False
-    name = people.get(pr_author, {}).get("name", "")
-    if name:
-        authors_url = "https://raw.githubusercontent.com/{repo}/{branch}/AUTHORS".format(
-            repo=pull_request["head"]["repo"]["full_name"].decode('utf-8'),
-            branch=pull_request["head"]["ref"].decode('utf-8'),
-        )
-        authors_resp = github.get(authors_url)
-        if authors_resp.ok:
-            authors_content = authors_resp.text
-            if name in authors_content:
-                in_authors_file = True
-
     return render_template("github_community_pr_comment.md.j2",
         user=pull_request["user"]["login"].decode('utf-8'),
         repo=pull_request["base"]["repo"]["full_name"].decode('utf-8'),
         number=pull_request["number"],
         issue_key=jira_issue["key"].decode('utf-8'),
         has_signed_agreement=has_signed_agreement,
-        in_authors_file=in_authors_file,
     )
 
 

--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -26,10 +26,6 @@ GitHub pull request interface. As a reminder,
     [signed contributor agreement](http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf)
     or indicated your institutional affiliation.
   {%- endif %}
-  {%- if not in_authors_file %}
-    If you like, you can add yourself to the [AUTHORS](https://github.com/{{ repo }}/blob/master/AUTHORS) 
-    file for this repo, though that isn't required.
-  {%- endif %}
   {%- if not has_signed_agreement or not in_authors_file %}
     Please see the [CONTRIBUTING](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst)
     file for more information.

--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -24,10 +24,7 @@ GitHub pull request interface. As a reminder,
   {%- if not has_signed_agreement %}
     We can't start reviewing your pull request until you've submitted a
     [signed contributor agreement](http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf)
-    or indicated your institutional affiliation.
-  {%- endif %}
-  {%- if not has_signed_agreement %}
-    Please see the [CONTRIBUTING](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst)
+    or indicated your institutional affiliation. Please see the [CONTRIBUTING](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst)
     file for more information.
   {%- endif %}
 {% endfilter %}

--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -26,7 +26,7 @@ GitHub pull request interface. As a reminder,
     [signed contributor agreement](http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf)
     or indicated your institutional affiliation.
   {%- endif %}
-  {%- if not has_signed_agreement or not in_authors_file %}
+  {%- if not has_signed_agreement %}
     Please see the [CONTRIBUTING](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst)
     file for more information.
   {%- endif %}

--- a/tests/test_pr_comments.py
+++ b/tests/test_pr_comments.py
@@ -87,7 +87,7 @@ def test_community_pr_comment_not_in_authors_file(app, requests_mocker):
         comment = github_community_pr_comment(pr, jira)
     assert "[TNL-12345](https://openedx.atlassian.net/browse/TNL-12345)" in comment
     assert "can't start reviewing your pull request" not in comment
-    assert "you can add yourself to the [AUTHORS]" in comment
+    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 
@@ -107,7 +107,7 @@ def test_community_pr_comment_no_authors_file_at_all(app, requests_mocker):
         comment = github_community_pr_comment(pr, jira)
     assert "[TNL-12345](https://openedx.atlassian.net/browse/TNL-12345)" in comment
     assert "can't start reviewing your pull request" not in comment
-    assert "you can add yourself to the [AUTHORS]" in comment
+    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 
@@ -118,7 +118,7 @@ def test_community_pr_comment_no_author(app):
         comment = github_community_pr_comment(pr, jira)
     assert "[FOO-1](https://openedx.atlassian.net/browse/FOO-1)" in comment
     assert "can't start reviewing your pull request" in comment
-    assert "you can add yourself to the [AUTHORS]" in comment
+    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 

--- a/tests/test_pr_comments.py
+++ b/tests/test_pr_comments.py
@@ -67,7 +67,6 @@ def test_community_pr_comment(app, requests_mocker):
         comment = github_community_pr_comment(pr, jira)
     assert "[TNL-12345](https://openedx.atlassian.net/browse/TNL-12345)" in comment
     assert "can't start reviewing your pull request" not in comment
-    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 
@@ -87,7 +86,6 @@ def test_community_pr_comment_not_in_authors_file(app, requests_mocker):
         comment = github_community_pr_comment(pr, jira)
     assert "[TNL-12345](https://openedx.atlassian.net/browse/TNL-12345)" in comment
     assert "can't start reviewing your pull request" not in comment
-    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 
@@ -107,7 +105,6 @@ def test_community_pr_comment_no_authors_file_at_all(app, requests_mocker):
         comment = github_community_pr_comment(pr, jira)
     assert "[TNL-12345](https://openedx.atlassian.net/browse/TNL-12345)" in comment
     assert "can't start reviewing your pull request" not in comment
-    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 
@@ -118,7 +115,6 @@ def test_community_pr_comment_no_author(app):
         comment = github_community_pr_comment(pr, jira)
     assert "[FOO-1](https://openedx.atlassian.net/browse/FOO-1)" in comment
     assert "can't start reviewing your pull request" in comment
-    assert "you can add yourself to the [AUTHORS]" not in comment
     assert not comment.startswith((" ", "\n", "\t"))
 
 


### PR DESCRIPTION
I simply removed the AUTHORS line from the template and then changed the tests to check that it didn't appear in any comments. The tests pass, but is that all that needs to be done?