### PR TITLE
Update openedx-webhooks with oep-18.

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,7 +2,7 @@ owner: nedbat
 oeps:
     oep-2: true
     oep-7: false
-    oep-18: false
+    oep-18: true
 
 tags:
     - backend-service

--- a/openedx_webhooks/lib/edx_repo_tools_data/models.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/models.py
@@ -140,7 +140,7 @@ class Person(object):
             # TODO: Is there a better way to handle this edge case?
             #       Is it even possible to have no agreement and no
             #       expiration data at all?
-            yesterday = arrow.now().replace(days=-1).date()
+            yesterday = arrow.now().shift(days=-1).date()
             expires_on = yesterday
 
         if not self.agreement and self._before:

--- a/openedx_webhooks/lib/edx_repo_tools_data/test/models/test_person.py
+++ b/openedx_webhooks/lib/edx_repo_tools_data/test/models/test_person.py
@@ -45,7 +45,7 @@ class TestAgreementExpiresOn:
 
     def test_no_agreement(self):
         p = Person('', {'agreement': 'none'})
-        yesterday = arrow.now().replace(days=-1).date()
+        yesterday = arrow.now().shift(days=-1).date()
         assert p.agreement_expires_on == yesterday
 
 

--- a/openedx_webhooks/lib/github/test/utils/test_get_most_recent_hook.py
+++ b/openedx_webhooks/lib/github/test/utils/test_get_most_recent_hook.py
@@ -29,8 +29,8 @@ def single_inactive():
 @pytest.fixture
 def multiple_active():
     hooks = [
-        Hook(active=True, updated_at=now.replace(months=-10).datetime),
-        Hook(active=True, updated_at=now.replace(days=-10).datetime),
+        Hook(active=True, updated_at=now.shift(months=-10).datetime),
+        Hook(active=True, updated_at=now.shift(days=-10).datetime),
         Hook(active=True, updated_at=now.datetime),
     ]
     return hooks
@@ -39,8 +39,8 @@ def multiple_active():
 @pytest.fixture
 def multiple_inactive():
     hooks = [
-        Hook(active=False, updated_at=now.replace(months=-10).datetime),
-        Hook(active=False, updated_at=now.replace(days=-10).datetime),
+        Hook(active=False, updated_at=now.shift(months=-10).datetime),
+        Hook(active=False, updated_at=now.shift(days=-10).datetime),
         Hook(active=False, updated_at=now.datetime),
     ]
     return hooks
@@ -49,8 +49,8 @@ def multiple_inactive():
 @pytest.fixture
 def multiple_mixed():
     hooks = [
-        Hook(active=True, updated_at=now.replace(months=-10).datetime),
-        Hook(active=True, updated_at=now.replace(days=-10).datetime),
+        Hook(active=True, updated_at=now.shift(months=-10).datetime),
+        Hook(active=True, updated_at=now.shift(days=-10).datetime),
         Hook(active=False, updated_at=now.datetime),
     ]
     return hooks

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,10 +1,12 @@
 # Core requirements for using this application
 
-Flask-Dance[sqla]>=0.9,<0.10
+-c constraints.txt
+
+Flask-Dance[sqla]
 Flask-SQLAlchemy
 Flask
-celery>=3,<4
-github3.py>=0.9,<1.0
+celery
+github3.py
 
 Flask-SSLify
 Flask-Script
@@ -22,7 +24,7 @@ jira
 oauthlib[signedtoken]
 psycopg2
 raven
-redis<3.0       # 3.0 broke something: https://github.com/andymccurdy/redis-py/issues/1068
+redis
 requests
 requests-oauthlib
-rq==0.12.0
+rq

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,59 +6,58 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-arrow==0.14.2
-asn1crypto==0.24.0        # via cryptography
-backports.functools-lru-cache==1.5
+arrow==0.15.4
+backports.functools-lru-cache==1.6.1
 billiard==3.3.0.23        # via celery
 blinker==1.4
 celery==3.1.26.post2
-certifi==2019.6.16        # via requests
-cffi==1.12.3              # via cryptography
+certifi==2019.11.28       # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0
-contextlib2==0.5.5        # via raven
-cryptography==2.7
+contextlib2==0.6.0.post1  # via raven
+cryptography==2.8
 defusedxml==0.6.0         # via jira
 enum34==1.1.6             # via cryptography
 flask-dance[sqla]==0.9.0
 flask-script==2.0.6
-flask-sqlalchemy==2.4.0
+flask-sqlalchemy==2.4.1
 flask-sslify==0.1.5
-flask==1.0.3
+flask==1.1.1
 functools32==3.2.3.post2
 github3.py==0.9.6
-gunicorn==19.9.0
+gunicorn==19.10.0
 idna==2.8                 # via requests
-ipaddress==1.0.22         # via cryptography
+ipaddress==1.0.23         # via cryptography
 iso8601==0.1.12
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask
+jinja2==2.10.3            # via flask
 jira==2.0.0
 kombu==3.0.37             # via celery
 lazy==1.4                 # via flask-dance
 markupsafe==1.1.1         # via jinja2
-oauthlib[signedtoken]==3.0.1
-pbr==5.3.1                # via jira
-psycopg2==2.8.3
+oauthlib[signedtoken]==3.1.0
+pbr==5.4.4                # via jira
+psycopg2==2.8.4
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via oauthlib
-python-dateutil==2.8.0    # via arrow
-pytz==2019.1              # via celery
-pyyaml==5.1.1
+python-dateutil==2.8.1    # via arrow
+pytz==2019.3              # via celery
+pyyaml==5.2
 raven==6.10.0
 redis==2.10.6
-requests-oauthlib==1.2.0
+requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1  # via jira
 requests==2.22.0
 rq==0.12.0
-six==1.12.0               # via cryptography, flask-dance, jira, python-dateutil, sqlalchemy-utils
-sqlalchemy-utils==0.34.0  # via flask-dance
-sqlalchemy==1.3.5         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+six==1.13.0               # via cryptography, flask-dance, jira, python-dateutil, sqlalchemy-utils
+sqlalchemy-utils==0.36.0  # via flask-dance
+sqlalchemy==1.3.11        # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
 uritemplate.py==3.0.2     # via github3.py
 uritemplate==3.0.0        # via uritemplate.py
-urllib3==1.25.3           # via requests
+urllib3==1.25.7           # via requests
 urlobject==2.4.3
-werkzeug==0.15.4          # via flask
+werkzeug==0.16.0          # via flask
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via jira
+# setuptools

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,17 @@
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why. Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
+
+Flask-Dance[sqla]==0.9.0
+celery==3.1.26.post2
+github3.py==0.9.6
+redis==2.10.6      # 3.0 broke something: https://github.com/andymccurdy/redis-py/issues/1068
+rq==0.12.0
+rq-dashboard==0.5.0
+Sphinx==1.5.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,109 +7,108 @@
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-arrow==0.14.2
-asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via pylint, pylint-celery
+arrow==0.15.4
+astroid==1.6.6            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.3.0             # via pytest
 babel==2.7.0              # via sphinx
-backports.functools-lru-cache==1.5
+backports.functools-lru-cache==1.6.1
 betamax==0.8.1
 billiard==3.3.0.23        # via celery
 bleach==3.1.0             # via readme-renderer
 blinker==1.4
 celery==3.1.26.post2
-certifi==2019.6.16        # via requests
-cffi==1.12.3              # via cryptography
+certifi==2019.11.28       # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0
 codecov==2.0.15
-configparser==3.7.4       # via importlib-metadata, pylint
-contextlib2==0.5.5        # via importlib-metadata, raven
-coverage==4.5.3           # via codecov, pytest-cov
-cryptography==2.7
+configparser==4.0.2       # via importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via importlib-metadata, raven
+coverage==4.5.4           # via codecov, pytest-cov
+cryptography==2.8
 defusedxml==0.6.0         # via jira
-docutils==0.14            # via readme-renderer, sphinx
-edx-lint==1.3.0
+docutils==0.15.2          # via readme-renderer, sphinx
+edx-lint==1.4.1
 enum34==1.1.6             # via astroid, cryptography
 flask-dance[sqla]==0.9.0
 flask-script==2.0.6
-flask-sqlalchemy==2.4.0
+flask-sqlalchemy==2.4.1
 flask-sslify==0.1.5
-flask==1.0.3
+flask==1.1.1
 funcsigs==1.0.2           # via mock, pytest
 functools32==3.2.3.post2
-futures==3.2.0            # via isort
+futures==3.3.0            # via isort
 github3.py==0.9.6
-gunicorn==19.9.0
+gunicorn==19.10.0
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.18  # via pluggy, pytest
-ipaddress==1.0.22         # via cryptography
+importlib-metadata==1.2.0  # via pluggy, pytest
+ipaddress==1.0.23         # via cryptography
 iso8601==0.1.12
 isort==4.3.21
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask, sphinx
+jinja2==2.10.3            # via flask, sphinx
 jira==2.0.0
 kombu==3.0.37             # via celery
-lazy-object-proxy==1.4.1  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via flask-dance
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via pytest-mock
-more-itertools==5.0.0     # via pytest
-oauthlib[signedtoken]==3.0.1
-packaging==19.0           # via pytest
-pathlib2==2.3.4           # via importlib-metadata, pytest
-pbr==5.3.1                # via jira
-pip-tools==3.8.0
-pluggy==0.12.0            # via pytest
-psycopg2==2.8.3
+more-itertools==5.0.0     # via pytest, zipp
+oauthlib[signedtoken]==3.1.0
+packaging==19.2           # via pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest
+pbr==5.4.4                # via jira
+pip-tools==4.3.0
+pluggy==0.13.1            # via pytest
+psycopg2==2.8.4
 py==1.8.0                 # via pytest
 pycparser==2.19           # via cffi
-pygments==2.4.2           # via readme-renderer, sphinx
+pygments==2.5.2           # via readme-renderer, sphinx
 pyjwt==1.7.1              # via oauthlib
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.0          # via packaging
-pytest-cov==2.7.1
-pytest-mock==1.10.4
-pytest==4.6.4
-python-dateutil==2.8.0    # via arrow
+pylint-django==0.11.1     # via edx-lint
+pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
+pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.5          # via packaging
+pytest-cov==2.8.1
+pytest-mock==1.13.0
+pytest==4.6.7
+python-dateutil==2.8.1    # via arrow
 python-dotenv==0.10.3
-pytz==2019.1
-pyyaml==5.1.1
+pytz==2019.3
+pyyaml==5.2
 raven==6.10.0
 readme-renderer==24.0
 redis==2.10.6
-requests-mock==1.6.0
-requests-oauthlib==1.2.0
+requests-mock==1.7.0
+requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1  # via jira
 requests==2.22.0
-rq-dashboard==0.5.1
+rq-dashboard==0.5.0
 rq==0.12.0
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0               # via astroid, bleach, cryptography, edx-lint, flask-dance, jira, mock, packaging, pathlib2, pip-tools, pylint, pytest, python-dateutil, readme-renderer, requests-mock, singledispatch, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
-snowballstemmer==1.9.0    # via sphinx
+six==1.13.0               # via astroid, bleach, cryptography, edx-lint, flask-dance, jira, mock, more-itertools, packaging, pathlib2, pip-tools, pylint, pytest, python-dateutil, readme-renderer, requests-mock, singledispatch, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
+snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.5.6
 sphinxcontrib-httpdomain==1.7.0
-sqlalchemy-utils==0.34.0  # via flask-dance
-sqlalchemy==1.3.5         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
-typing==3.7.4             # via python-dotenv
+sqlalchemy-utils==0.36.0  # via flask-dance
+sqlalchemy==1.3.11        # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+typing==3.7.4.1           # via python-dotenv
 uritemplate.py==3.0.2     # via github3.py
 uritemplate==3.0.0        # via uritemplate.py
-urllib3==1.25.3           # via requests
+urllib3==1.25.7           # via requests
 urlobject==2.4.3
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via bleach
-werkzeug==0.15.4          # via flask
+werkzeug==0.16.0          # via flask
 wrapt==1.11.2             # via astroid
-zipp==0.5.1               # via importlib-metadata
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via jira
+# setuptools

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -1,6 +1,8 @@
 # Requirements for documentation validation
 
-Sphinx>=1.5,<1.6         # Documentation builder
+-c constraints.txt
+
+Sphinx         # Documentation builder
 
 readme_renderer           # Validates README.rst for usage on PyPI
 sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.8.0
-six==1.12.0               # via pip-tools
+pip-tools==4.3.0
+six==1.13.0               # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,92 +7,91 @@
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-arrow==0.14.2
-asn1crypto==0.24.0        # via cryptography
+arrow==0.15.4
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.3.0             # via pytest
 babel==2.7.0              # via sphinx
-backports.functools-lru-cache==1.5
+backports.functools-lru-cache==1.6.1
 betamax==0.8.1
 billiard==3.3.0.23        # via celery
 bleach==3.1.0             # via readme-renderer
 blinker==1.4
 celery==3.1.26.post2
-certifi==2019.6.16        # via requests
-cffi==1.12.3              # via cryptography
+certifi==2019.11.28       # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0
 codecov==2.0.15
-configparser==3.7.4       # via importlib-metadata
-contextlib2==0.5.5        # via importlib-metadata, raven
-coverage==4.5.3           # via codecov, pytest-cov
-cryptography==2.7
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, raven
+coverage==4.5.4           # via codecov, pytest-cov
+cryptography==2.8
 defusedxml==0.6.0         # via jira
-docutils==0.14            # via readme-renderer, sphinx
+docutils==0.15.2          # via readme-renderer, sphinx
 enum34==1.1.6             # via cryptography
 flask-dance[sqla]==0.9.0
 flask-script==2.0.6
-flask-sqlalchemy==2.4.0
+flask-sqlalchemy==2.4.1
 flask-sslify==0.1.5
-flask==1.0.3
+flask==1.1.1
 funcsigs==1.0.2           # via mock, pytest
 functools32==3.2.3.post2
 github3.py==0.9.6
-gunicorn==19.9.0
+gunicorn==19.10.0
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.18  # via pluggy, pytest
-ipaddress==1.0.22         # via cryptography
+importlib-metadata==1.2.0  # via pluggy, pytest
+ipaddress==1.0.23         # via cryptography
 iso8601==0.1.12
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask, sphinx
+jinja2==2.10.3            # via flask, sphinx
 jira==2.0.0
 kombu==3.0.37             # via celery
 lazy==1.4                 # via flask-dance
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5               # via pytest-mock
-more-itertools==5.0.0     # via pytest
-oauthlib[signedtoken]==3.0.1
-packaging==19.0           # via pytest
-pathlib2==2.3.4           # via importlib-metadata, pytest
-pbr==5.3.1                # via jira
-pluggy==0.12.0            # via pytest
-psycopg2==2.8.3
+more-itertools==5.0.0     # via pytest, zipp
+oauthlib[signedtoken]==3.1.0
+packaging==19.2           # via pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest
+pbr==5.4.4                # via jira
+pluggy==0.13.1            # via pytest
+psycopg2==2.8.4
 py==1.8.0                 # via pytest
 pycparser==2.19           # via cffi
-pygments==2.4.2           # via readme-renderer, sphinx
+pygments==2.5.2           # via readme-renderer, sphinx
 pyjwt==1.7.1              # via oauthlib
-pyparsing==2.4.0          # via packaging
-pytest-cov==2.7.1
-pytest-mock==1.10.4
-pytest==4.6.4
-python-dateutil==2.8.0    # via arrow
-pytz==2019.1
-pyyaml==5.1.1
+pyparsing==2.4.5          # via packaging
+pytest-cov==2.8.1
+pytest-mock==1.13.0
+pytest==4.6.7
+python-dateutil==2.8.1    # via arrow
+pytz==2019.3
+pyyaml==5.2
 raven==6.10.0
 readme-renderer==24.0
 redis==2.10.6
-requests-mock==1.6.0
-requests-oauthlib==1.2.0
+requests-mock==1.7.0
+requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1  # via jira
 requests==2.22.0
 rq==0.12.0
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via bleach, cryptography, flask-dance, jira, mock, packaging, pathlib2, pytest, python-dateutil, readme-renderer, requests-mock, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
-snowballstemmer==1.9.0    # via sphinx
+six==1.13.0               # via bleach, cryptography, flask-dance, jira, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, readme-renderer, requests-mock, sphinx, sphinxcontrib-httpdomain, sqlalchemy-utils
+snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.5.6
 sphinxcontrib-httpdomain==1.7.0
-sqlalchemy-utils==0.34.0  # via flask-dance
-sqlalchemy==1.3.5         # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
+sqlalchemy-utils==0.36.0  # via flask-dance
+sqlalchemy==1.3.11        # via flask-dance, flask-sqlalchemy, sqlalchemy-utils
 uritemplate.py==3.0.2     # via github3.py
 uritemplate==3.0.0        # via uritemplate.py
-urllib3==1.25.3           # via requests
+urllib3==1.25.7           # via requests
 urlobject==2.4.3
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via bleach
-werkzeug==0.15.4          # via flask
-zipp==0.5.1               # via importlib-metadata
+werkzeug==0.16.0          # via flask
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via jira
+# setuptools


### PR DESCRIPTION
### [PROD-1010](https://openedx.atlassian.net/browse/PROD-1010)

### Description

Repo: https://github.com/edx/openedx-webhooks
OEP-18: https://open-edx-proposals.readthedocs.io/en/latest/oep-0018-bp-python-dependencies.html

Before merging run full test suite and ensure nothing is failing.

### Code changes
some code changes were made regarding the update of `arrow` package. The functionality to change current time based on days/months of `arrow` instance has changed and moved from the `replace()` function to the `shift()` function as visible in this example as well as code change:

```        
    yesterday = arrow.now().replace(days=-1).date()
    yesterday = arrow.now().shift(days=-1).date()
```

### Reviewers
 - [ ] @awaisdar001 
 - [ ] @DawoudSheraz 