### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -364,8 +364,8 @@ TODO
 .. _Heroku Command Line: https://devcenter.heroku.com/articles/heroku-command-line
 .. _pipeline: https://devcenter.heroku.com/articles/pipelines
 
-.. |Build Status| image:: https://travis-ci.org/edx/openedx-webhooks.svg?branch=master
-   :target: https://travis-ci.org/edx/openedx-webhooks
+.. |Build Status| image:: https://travis-ci.com/edx/openedx-webhooks.svg?branch=master
+   :target: https://travis-ci.com/edx/openedx-webhooks
 .. |Coverage Status| image:: http://codecov.io/github/edx/openedx-webhooks/coverage.svg?branch=master
    :target: http://codecov.io/github/edx/openedx-webhooks?branch=master
 .. |Documentation badge| image:: https://readthedocs.org/projects/openedx-webhooks/badge/?version=latest


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089