### PR TITLE
feat: Add branches field for core committers

### DIFF
--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -142,7 +142,8 @@ def _is_pull_request(pull_request: PrDict, kind: str) -> bool:
 
 def is_committer_pull_request(pull_request: PrDict) -> bool:
     """
-    Was this pull request created by a core committer for this repo?
+    Was this pull request created by a core committer for this repo
+    or branch?
     """
     person = _pr_author_data(pull_request)
     if person is None:
@@ -152,6 +153,7 @@ def is_committer_pull_request(pull_request: PrDict) -> bool:
 
     repo = pull_request["base"]["repo"]["full_name"]
     org = repo.partition("/")[0]
+    branch = pull_request["base"]["ref"]
     commit_rights = person["committer"]
     if not commit_rights:
         return False
@@ -161,6 +163,12 @@ def is_committer_pull_request(pull_request: PrDict) -> bool:
     if "repos" in commit_rights:
         if repo in commit_rights["repos"]:
             return True
+    if "branches" in commit_rights:
+        for access_branch in commit_rights["branches"]:
+            if access_branch.endswith("*") and branch.startswith(access_branch[:-1]):
+                return True
+            elif branch == access_branch:
+                return True
     return False
 
 

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -119,6 +119,7 @@ class PullRequest:
     draft: bool = False
     additions: Optional[int] = None
     deletions: Optional[int] = None
+    ref: str = ""
 
     def as_json(self, brief=False) -> Dict:
         j = {
@@ -131,6 +132,7 @@ class PullRequest:
             "labels": [self.repo.get_label(l).as_json() for l in sorted(self.labels)],
             "base": {
                 "repo": self.repo.as_json(),
+                "ref": self.ref,
             },
             "created_at": self.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "url": f"{self.repo.github.host}/repos/{self.repo.full_name}/pulls/{self.number}",

--- a/tests/repo_data/people.yaml
+++ b/tests/repo_data/people.yaml
@@ -38,6 +38,8 @@ hollyhunter:
     committer:
         repos:
             - edx/edx-platform
+        branches:
+            - open-release/*
         champions:
             - nedbat
     before:
@@ -92,6 +94,8 @@ pdpinch:
             - edx/ccx-keys
         champions:
             - feanil
+        branches:
+            - open-release/aspen.1
     other_emails:
     - github@hawklake.com
     comments:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -85,6 +85,29 @@ def test_repo_committers(make_pull_request):
     assert not is_internal_pull_request(pr)
     assert not is_committer_pull_request(pr)
 
+def test_base_branch_committers(make_pull_request):
+    pr = make_pull_request(
+        "hollyhunter",
+        repo="edx/fake-release-repo",
+        ref="open-release/birch.1"
+    )
+    assert not is_internal_pull_request(pr)
+    assert is_committer_pull_request(pr)
+    pr = make_pull_request(
+        "hollyhunter",
+        repo="edx/fake-release-repo",
+        ref="master"
+    )
+    assert not is_internal_pull_request(pr)
+    assert not is_committer_pull_request(pr)
+    pr = make_pull_request(
+        "pdpinch",
+        repo="edx/fake-release-repo",
+        ref="open-release/birch.1"
+    )
+    assert not is_internal_pull_request(pr)
+    assert not is_committer_pull_request(pr)
+
 def test_current_person_no_institution():
     people = get_people_file()
     created_at = datetime.today()


### PR DESCRIPTION
Add a new, optional field `branches` that gives core committers access to all branches that are specified in the set.

`branches` is a set of one or more specified branches that CCs have merge rights to.

`branches` can be a specific branch, such as `open-release/maple.1`, or a wildcard such as `open-release*`

This is dependent on https://github.com/edx/repo-tools-data-schema/pull/3 