### PR TITLE
feat: add Github label to PR if CLA still needed

### DIFF
--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -263,6 +263,7 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
     if not has_signed_agreement:
         desired.bot_comments.add(BotComment.NEED_CLA)
         desired.jira_initial_status = "Community Manager Review"
+        desired.github_labels.add('NEED-CLA')
 
     if state == "closed":
         desired.jira_status = "Rejected"

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -86,7 +86,11 @@ def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jir
     assert not is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {"community manager review", "open-source-contribution"}
+    assert pr.labels == {
+        'community manager review',
+        'open-source-contribution',
+        'NEED-CLA',
+    }
 
 
 def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_jira):
@@ -667,7 +671,11 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
     else:
         assert pr_type == "nocla"
         assert is_comment_kind(BotComment.NEED_CLA, body)
-        assert pr.labels == {"community manager review", "open-source-contribution"}
+        assert pr.labels == {
+            'community manager review',
+            'open-source-contribution',
+            'NEED-CLA',
+        }
 
     if jira_got_fiddled:
         # Someone changes the status from "Waiting on Author" manually.


### PR DESCRIPTION
This is part of a larger effort to ensure CLAs are signed pre-merge,
when needed.

It serves as a minimal first step, as well as providing an opportunity
for me (stvstnfrd) to familiarize myself with the Heroku workflow.