### PR TITLE
fix: protect all pages with basic auth

### DIFF
--- a/changelog.d/20210818_132501_nedbat_basic_auth_everywhere.rst
+++ b/changelog.d/20210818_132501_nedbat_basic_auth_everywhere.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- fix: all UI pages are now protected with basic auth.

--- a/openedx_webhooks/github_views.py
+++ b/openedx_webhooks/github_views.py
@@ -18,7 +18,7 @@ from openedx_webhooks.tasks.github import (
     rescan_organization_task,
 )
 from openedx_webhooks.utils import (
-    is_valid_payload, minimal_wsgi_environ, sentry_extra_context
+    is_valid_payload, minimal_wsgi_environ, sentry_extra_context, requires_auth
 )
 
 github_bp = Blueprint('github_views', __name__)
@@ -102,6 +102,7 @@ def hook_receiver():
 
 
 @github_bp.route("/rescan", methods=("GET",))
+@requires_auth
 def rescan_get():
     """
     Display a friendly HTML form for rescanning GitHub pull requests.
@@ -110,6 +111,7 @@ def rescan_get():
 
 
 @github_bp.route("/rescan", methods=("POST",))
+@requires_auth
 def rescan():
     """
     Re-scan GitHub repositories to find pull requests that need OSPR issues
@@ -150,6 +152,7 @@ def rescan():
 
 
 @github_bp.route("/process_pr", methods=("GET",))
+@requires_auth
 def process_pr_get():
     """
     Display a friendly HTML form for processing or re-processing a pull request.
@@ -158,6 +161,7 @@ def process_pr_get():
 
 
 @github_bp.route("/process_pr", methods=("POST",))
+@requires_auth
 def process_pr():
     """
     Process (or re-process) a pull request.
@@ -189,6 +193,7 @@ def process_pr():
 
 
 @github_bp.route("/generate_error", methods=("GET",))
+@requires_auth
 def generate_error():
     """
     Used to generate an error message to test error handling

--- a/openedx_webhooks/jira_views.py
+++ b/openedx_webhooks/jira_views.py
@@ -17,6 +17,7 @@ from openedx_webhooks.tasks.github_work import synchronize_labels
 from openedx_webhooks.utils import (
     jira_paginated_get, sentry_extra_context,
     github_pr_num, github_pr_url, github_pr_repo,
+    requires_auth,
 )
 
 jira_bp = Blueprint('jira_views', __name__)
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 @jira_bp.route("/issue/rescan", methods=("GET",))
+@requires_auth
 def rescan_issues_get():
     """
     Display a friendly HTML form for re-scanning JIRA issues.
@@ -32,6 +34,7 @@ def rescan_issues_get():
 
 
 @jira_bp.route("/issue/rescan", methods=("POST",))
+@requires_auth
 def rescan_issues():
     """
     Re-scan all JIRA issues that are in the "Needs Triage" state. If any were

--- a/openedx_webhooks/tasks/__init__.py
+++ b/openedx_webhooks/tasks/__init__.py
@@ -6,6 +6,8 @@ import logging_tree
 
 from openedx_webhooks import celery, log_level
 from openedx_webhooks.debug import print_long
+from openedx_webhooks.utils import requires_auth
+
 
 # Set up Celery logging.
 logger = get_task_logger(__name__)
@@ -18,6 +20,7 @@ logger.setLevel(log_level)
 tasks = Blueprint('tasks', __name__)
 
 @tasks.route('/status/<task_id>')
+@requires_auth
 def status(task_id):
     result = celery.AsyncResult(task_id)
     return jsonify({
@@ -26,6 +29,7 @@ def status(task_id):
     })
 
 @tasks.route('/statusrepr/<task_id>')
+@requires_auth
 def statusrepr(task_id):
     """Get the status of a task, but repr() everything so we can see JSON failures from /status/<task_id>"""
     result = celery.AsyncResult(task_id)
@@ -35,6 +39,7 @@ def statusrepr(task_id):
     })
 
 @tasks.route('/status/group:<group_id>')
+@requires_auth
 def group_status(group_id):
     # NOTE: This will only work if the GroupResult
     # has previously called .save() on itself

--- a/openedx_webhooks/templates/main.html
+++ b/openedx_webhooks/templates/main.html
@@ -26,8 +26,8 @@
         <a href="{{ url_for("github.login") }}">Authenticate</a>
         {% endif %}
       </li>
-      <li><a href="{{ url_for("github_views.rescan") }}">Rescan Pull Requests</a></li>
-      <li><a href="{{ url_for("github_views.process_pr") }}">Process Pull Request</a></li>
+      <li><a href="{{ url_for("github_views.rescan_get") }}">Rescan Pull Requests</a></li>
+      <li><a href="{{ url_for("github_views.process_pr_get") }}">Process Pull Request</a></li>
       <li><a href="{{ url_for("github_views.generate_error") }}">Generate Error</a></li>
     </ul>
     <h2>JIRA</h2>
@@ -40,7 +40,7 @@
         <a href="{{ url_for("jira.login") }}">Authenticate</a>
         {% endif %}
       </li>
-      <li><a href="{{ url_for("jira_views.rescan_issues") }}">Rescan Issues</a></li>
+      <li><a href="{{ url_for("jira_views.rescan_issues_get") }}">Rescan Issues</a></li>
     </ul>
     </body>
 </html>


### PR DESCRIPTION
Also, use the correct GET view names in the HTML template, although the
POST view names worked also, since it was only getting the URL, which is
the same for both.